### PR TITLE
fix broken paths in example index.html file

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,8 +8,8 @@
 
     <title>Macy.js - A lightweight, dependency free, JavaScript masonry layout library</title>
 
-    <link rel="stylesheet" href="demo/assets/css/macy.css">
-    <link rel="stylesheet" href="demo/assets/css/icons.css">
+    <link rel="stylesheet" href="assets/css/macy.css">
+    <link rel="stylesheet" href="assets/css/icons.css">
     <link rel="apple-touch-icon" sizes="57x57" href="assets/img/favicons/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="assets/img/favicons/apple-touch-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="assets/img/favicons/apple-touch-icon-72x72.png">
@@ -24,17 +24,17 @@
     <link rel="icon" type="image/png" href="assets/img/favicons/favicon-96x96.png" sizes="96x96">
     <link rel="icon" type="image/png" href="assets/img/favicons/android-chrome-192x192.png" sizes="192x192">
     <link rel="icon" type="image/png" href="assets/img/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="demo/assets/img/favicons/manifest.json">
-    <link rel="shortcut icon" href="demo/assets/img/favicons/favicon.ico">
+    <link rel="manifest" href="assets/img/favicons/manifest.json">
+    <link rel="shortcut icon" href="assets/img/favicons/favicon.ico">
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="demo/assets/img/favicons/mstile-144x144.png">
-    <meta name="msapplication-config" content="demo/assets/img/favicons/browserconfig.xml">
+    <meta name="msapplication-TileImage" content="assets/img/favicons/mstile-144x144.png">
+    <meta name="msapplication-config" content="assets/img/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body>
     <header class="hero">
         <div class="container">
-            <img class="logo" src="demo/assets/img/macy-logo.svg" style="width: 146px" alt="">
+            <img class="logo" src="assets/img/macy-logo.svg" style="width: 146px" alt="">
             <h1 class="hero__title">Macy.js is a lightweight, dependency free, 2kb (gzipped) masonry layout library. Designed for hassle free configuration and use for your content.</h1>
             <a href="https://github.com/bigbitecreative/macy.js/" class="btn has-icon icon-github">Download and docs on GitHub</a>
         </div>


### PR DESCRIPTION
This PR addresses a number of assets (critically the main CSS file) that could not be loaded in the example index.html file due to incorrect paths in href attributes.

Before:
![before](https://user-images.githubusercontent.com/3317203/55744795-c3546300-5a03-11e9-9faa-909fc02d2189.PNG)

After:
![after](https://user-images.githubusercontent.com/3317203/55744802-c64f5380-5a03-11e9-8eaf-26b46c3b8ed6.PNG)
