### PR TITLE
Add jsDelivr CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Install with Bower:
 bower install macy
 ```
 
+Include via [jsDelivr CDN](https://www.jsdelivr.com/package/npm/macy):
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/macy@2"></script>
+```
+
 ## Usage
 ```javascript
 var macyInstance = Macy({


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an easier and faster option of using the project.